### PR TITLE
Define CRS and other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ BLN converter offers a very simple CLI. Although under development, it is alread
 
 Convert BLN to ESRI shape: 
 ```
-python -m bln-converter bln2shp -c {bln_folder}
+python -m bln-converter bln2shp -p {bln_folder}
 ```
 
 or use bln2geojson command to get a GeoJSON output. 
 ```
-python -m bln-converter bln2geojson -c {bln_folder}
+python -m bln-converter bln2geojson -p {bln_folder}
 ```
 
 BLN converter will find and process all BLN files in a given folder. The resultant files will be outputed to the origin folder. 

--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ BLN converter offers a very simple CLI. Although under development, it is alread
 
 Convert BLN to ESRI shape: 
 ```
-python -m bln-converter bln2shp -p {bln_folder}
+python -m bln-converter bln2shp -p {bln_folder} -crs {CRS}
 ```
 
 or use bln2geojson command to get a GeoJSON output. 
 ```
-python -m bln-converter bln2geojson -p {bln_folder}
+python -m bln-converter bln2geojson -p {bln_folder} -crs {CRS}
 ```
 
-BLN converter will find and process all BLN files in a given folder. The resultant files will be outputed to the origin folder. 
+BLN converter will find and process all BLN files in a given folder. The resultant files will be output to the origin folder. 
 
 
 Other commands or instructions can be found using the help command 

--- a/bln-converter/src/blnconverter.py
+++ b/bln-converter/src/blnconverter.py
@@ -15,7 +15,7 @@ logging.basicConfig(format='%(asctime)s | %(levelname)s : %(message)s',
                     level=logging.INFO, stream=sys.stdout)
 
 
-def converter(caminho: str, ext: str):
+def converter(caminho: str, ext: str, crs: int):
     caminho = Path(caminho)
     for item in caminho.glob("*.bln"):
         try:
@@ -27,7 +27,7 @@ def converter(caminho: str, ext: str):
             continue
         else:
             geometria = Polygon(zip(longitude, latitude))
-            poligono = gpd.GeoDataFrame(index=[0], crs={'init': 'epsg:4326'},
+            poligono = gpd.GeoDataFrame(index=[0], crs={'init': 'epsg:{}'.format(str(crs))},
                                         geometry=[geometria])
 
             formatos = {
@@ -51,11 +51,12 @@ def converter(caminho: str, ext: str):
 
 @click.command("bln2shp")
 @click.option('--path', '-p', help='Directory containing BLN files')
-def bln2shp(path: Path):
-    converter(path, ext="shp")
+@click.option('--crs', '-crs', help='Coordinate Reference System (crs), default is 4326')
+def bln2shp(path: Path, crs: int=4326):
+    converter(path, ext="shp", crs=crs)
     
     
 @click.command("bln2geojson")
 @click.option('--path', '-p', help='Directory containing BLN files')
-def bln2geojson(path: Path):
-    converter(path, ext="geojson")
+def bln2geojson(path: Path, crs: int=4326):
+    converter(path, ext="geojson", crs=crs)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
                       'click==7.1.2',
                       'click-plugins==1.1.1',
                       'cligj==0.7.1',
-                      'Fiona==1.8.18',
+                      'fiona==1.8.18',
                       'geopandas==0.8.1',
                       'munch==2.5.0',
                       'numpy==1.19.5',


### PR DESCRIPTION
Hi Eric,

I added functionality for supporting a -crs flag so that the user can define what projection their BLN files are in, and the resulting output from this tool will match (8aacb56 and bfb0cd5). 

I noticed an issue in the README/help that suggested using '-c', which should be '-p' for path (882a0b5).

There was also an issue installing (manually had to install fiona) which I believe is because of a typo (7bf303f).

Thanks for the tool, it was very helpful!